### PR TITLE
Add edit new instructor details

### DIFF
--- a/src/web/app/components/new-instructor-data-row/instructor-data.ts
+++ b/src/web/app/components/new-instructor-data-row/instructor-data.ts
@@ -1,0 +1,11 @@
+/**
+ * Represents the data of a new instructor.
+ */
+export interface InstructorData {
+    name: string;
+    email: string;
+    institution: string;
+    status: string;
+    joinLink?: string;
+    message?: string;
+}

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
@@ -12,7 +12,7 @@
 </td>
 <td>
   <div class="button-group" *ngIf="isBeingEdited && (instructor.status === 'PENDING' || instructor.status === 'FAIL')">
-    <button class="action-btn btn btn-sm btn-primary text-nowrap" id="confirm-edit-instructor-{{ index }}" style="margin-right: 10px;">Confirm</button>
+    <button class="action-btn btn btn-sm btn-primary text-nowrap" id="confirm-edit-instructor-{{ index }}" style="margin-right: 10px;" (click)="confirmEditInstructor()">Confirm</button>
     <button class="action-btn btn btn-sm btn-danger text-nowrap" id="cancel-edit-instructor-{{ index }}" style="margin-right: 10px;" (click)="cancelEditInstructor()">Cancel</button>
   </div>
   <div class="button-group" *ngIf="!isBeingEdited && (instructor.status === 'PENDING' || instructor.status === 'FAIL')">

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
@@ -1,11 +1,24 @@
-<td>{{ instructor.name }}</td>
-<td>{{ instructor.email }}</td>
-<td>{{ instructor.institution }}</td>
 <td>
-  <div class="button-group" *ngIf="instructor.status === 'PENDING' || instructor.status === 'FAIL'">
+  <span *ngIf="!isBeingEdited">{{ instructor.name }}</span>
+  <input *ngIf="isBeingEdited" class="form-control" type="text" id="instructor-{{ index }}-name" [(ngModel)]="editedInstructorName">
+</td>
+<td>
+  <span *ngIf="!isBeingEdited">{{ instructor.email }}</span>
+  <input *ngIf="isBeingEdited" class="form-control" type="text" id="instructor-{{ index }}-email" [(ngModel)]="editedInstructorEmail">
+</td>
+<td>
+  <span *ngIf="!isBeingEdited">{{ instructor.institution }}</span>
+  <input *ngIf="isBeingEdited" class="form-control" type="text" id="instructor-{{ index }}-institute" [(ngModel)]="editedInstructorInstitution">
+</td>
+<td>
+  <div class="button-group" *ngIf="isBeingEdited && (instructor.status === 'PENDING' || instructor.status === 'FAIL')">
+    <button class="action-btn btn btn-sm btn-primary text-nowrap" id="confirm-edit-instructor-{{ index }}" style="margin-right: 10px;">Confirm</button>
+    <button class="action-btn btn btn-sm btn-danger text-nowrap" id="cancel-edit-instructor-{{ index }}" style="margin-right: 10px;" (click)="cancelEditInstructor()">Cancel</button>
+  </div>
+  <div class="button-group" *ngIf="!isBeingEdited && (instructor.status === 'PENDING' || instructor.status === 'FAIL')">
     <button class="action-btn btn btn-sm btn-primary text-nowrap" id="add-instructor-{{ index }}" style="margin-right: 10px;" (click)="addInstructor()" [disabled]="activeRequests > 0">Add Instructor</button>
-    <button class="action-btn btn btn-sm btn-info text-nowrap" id="edit-instructor-{{ index }}" style="margin-right: 10px;">Edit</button>
-    <button class="action-btn btn btn-sm btn-danger" id="cancel-instructor-{{ index }}" (click)="cancelInstructor()">Cancel</button>
+    <button class="action-btn btn btn-sm btn-info text-nowrap" id="edit-instructor-{{ index }}" style="margin-right: 10px;" (click)="editInstructor()">Edit</button>
+    <button class="action-btn btn btn-sm btn-danger" id="remove-instructor-{{ index }}" (click)="removeInstructor()">Remove</button>
   </div>
 </td>
 <td>{{ instructor.status }}</td>

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.html
@@ -1,0 +1,17 @@
+<td>{{ instructor.name }}</td>
+<td>{{ instructor.email }}</td>
+<td>{{ instructor.institution }}</td>
+<td>
+  <div class="button-group" *ngIf="instructor.status === 'PENDING' || instructor.status === 'FAIL'">
+    <button class="action-btn btn btn-sm btn-primary text-nowrap" id="add-instructor-{{ index }}" style="margin-right: 10px;" (click)="addInstructor()" [disabled]="activeRequests > 0">Add Instructor</button>
+    <button class="action-btn btn btn-sm btn-info text-nowrap" id="edit-instructor-{{ index }}" style="margin-right: 10px;">Edit</button>
+    <button class="action-btn btn btn-sm btn-danger" id="cancel-instructor-{{ index }}" (click)="cancelInstructor()">Cancel</button>
+  </div>
+</td>
+<td>{{ instructor.status }}</td>
+<td style="width: 500px;">
+  <span *ngIf="instructor.status === 'SUCCESS'" id="message-instructor-{{ index }}">
+    Instructor "{{ instructor.name }}" has been successfully created. [<a href="{{ instructor.joinLink }}">join link</a>]
+  </span>
+  <span class="message" *ngIf="instructor.status === 'FAIL'" id="message-instructor-{{ index }}">{{ instructor.message }}</span>
+</td>

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.spec.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NewInstructorDataRowComponent } from './new-instructor-data-row.component';
+
+describe('NewInstructorDataRowComponent', () => {
+  let component: NewInstructorDataRowComponent;
+  let fixture: ComponentFixture<NewInstructorDataRowComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NewInstructorDataRowComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NewInstructorDataRowComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -1,0 +1,38 @@
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {InstructorData} from "./instructor-data";
+
+/**
+ * A single row of data of a new instructor.
+ */
+@Component({
+  selector: 'tr[tm-new-instructor-data-row]',
+  templateUrl: './new-instructor-data-row.component.html',
+  styleUrls: ['./new-instructor-data-row.component.scss']
+})
+export class NewInstructorDataRowComponent implements OnInit {
+  @Input() instructor!: InstructorData;
+  @Input() index!: number;
+  @Input() activeRequests!: number;
+  @Output() onAddInstructor: EventEmitter<void> = new EventEmitter();
+  @Output() onCancelInstructor: EventEmitter<void> = new EventEmitter();
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  /**
+   * Adds the instructor at the i-th index.
+   */
+  addInstructor(): void {
+    this.onAddInstructor.emit();
+  }
+
+  /**
+   * Cancels the instructor at the i-th index.
+   */
+  cancelInstructor(): void {
+    this.onCancelInstructor.emit();
+  }
+
+}

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -49,6 +49,18 @@ export class NewInstructorDataRowComponent implements OnInit {
   }
 
   /**
+   * Confirms the edit of the instructor's details.
+   */
+  confirmEditInstructor(): void {
+    this.instructor.name = this.editedInstructorName;
+    this.instructor.email = this.editedInstructorEmail;
+    this.instructor.institution = this.editedInstructorInstitution;
+    this.isBeingEdited = false;
+    // resetting here might be unnecessary
+    this.resetEditedInstructorDetails();
+  }
+
+  /**
    * Cancels the edit of the instructor's details.
    */
   cancelEditInstructor(): void {

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -14,7 +14,7 @@ export class NewInstructorDataRowComponent implements OnInit {
   @Input() index!: number;
   @Input() activeRequests!: number;
   @Output() onAddInstructor: EventEmitter<void> = new EventEmitter();
-  @Output() onCancelInstructor: EventEmitter<void> = new EventEmitter();
+  @Output() onRemoveInstructor: EventEmitter<void> = new EventEmitter();
   @Output() onToggleEditMode: EventEmitter<boolean> = new EventEmitter();
 
   isBeingEdited: boolean = false;
@@ -38,7 +38,7 @@ export class NewInstructorDataRowComponent implements OnInit {
    * Cancels the instructor at the i-th index.
    */
   removeInstructor(): void {
-    this.onCancelInstructor.emit();
+    this.onRemoveInstructor.emit();
   }
 
   /**

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -1,5 +1,5 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import {InstructorData} from "./instructor-data";
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { InstructorData } from "./instructor-data";
 
 /**
  * A single row of data of a new instructor.

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -15,6 +15,7 @@ export class NewInstructorDataRowComponent implements OnInit {
   @Input() activeRequests!: number;
   @Output() onAddInstructor: EventEmitter<void> = new EventEmitter();
   @Output() onCancelInstructor: EventEmitter<void> = new EventEmitter();
+  @Output() onToggleEditMode: EventEmitter<boolean> = new EventEmitter();
 
   isBeingEdited: boolean = false;
   editedInstructorName!: string;
@@ -45,7 +46,7 @@ export class NewInstructorDataRowComponent implements OnInit {
    */
   editInstructor(): void {
     this.resetEditedInstructorDetails();
-    this.isBeingEdited = true;
+    this.setEditModeAndAlertParent(true);
   }
 
   /**
@@ -55,7 +56,7 @@ export class NewInstructorDataRowComponent implements OnInit {
     this.instructor.name = this.editedInstructorName;
     this.instructor.email = this.editedInstructorEmail;
     this.instructor.institution = this.editedInstructorInstitution;
-    this.isBeingEdited = false;
+    this.setEditModeAndAlertParent(false);
     // resetting here might be unnecessary
     this.resetEditedInstructorDetails();
   }
@@ -64,7 +65,7 @@ export class NewInstructorDataRowComponent implements OnInit {
    * Cancels the edit of the instructor's details.
    */
   cancelEditInstructor(): void {
-    this.isBeingEdited = false;
+    this.setEditModeAndAlertParent(false);
     // resetting here might be unnecessary
     this.resetEditedInstructorDetails();
   }
@@ -76,6 +77,23 @@ export class NewInstructorDataRowComponent implements OnInit {
     this.editedInstructorName = this.instructor.name;
     this.editedInstructorEmail = this.instructor.email;
     this.editedInstructorInstitution = this.instructor.institution;
+  }
+
+  /**
+   * Sets whether edit mode is enabled and then alerts the parent of the new status.
+   *
+   * @param isEnabled Whether edit mode is enabled.
+   */
+  setEditModeAndAlertParent(isEnabled: boolean): void {
+    this.isBeingEdited = isEnabled;
+    this.alertParentEditModeToggled();
+  }
+
+  /**
+   * Alerts the parent that the edit mode was toggled and passes whether this is in edit mode or not.
+   */
+  alertParentEditModeToggled(): void {
+    this.onToggleEditMode.emit(this.isBeingEdited);
   }
 
 }

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.component.ts
@@ -16,6 +16,11 @@ export class NewInstructorDataRowComponent implements OnInit {
   @Output() onAddInstructor: EventEmitter<void> = new EventEmitter();
   @Output() onCancelInstructor: EventEmitter<void> = new EventEmitter();
 
+  isBeingEdited: boolean = false;
+  editedInstructorName!: string;
+  editedInstructorEmail!: string;
+  editedInstructorInstitution!: string;
+
   constructor() { }
 
   ngOnInit(): void {
@@ -31,8 +36,34 @@ export class NewInstructorDataRowComponent implements OnInit {
   /**
    * Cancels the instructor at the i-th index.
    */
-  cancelInstructor(): void {
+  removeInstructor(): void {
     this.onCancelInstructor.emit();
+  }
+
+  /**
+   * Starts editing the instructor.
+   */
+  editInstructor(): void {
+    this.resetEditedInstructorDetails();
+    this.isBeingEdited = true;
+  }
+
+  /**
+   * Cancels the edit of the instructor's details.
+   */
+  cancelEditInstructor(): void {
+    this.isBeingEdited = false;
+    // resetting here might be unnecessary
+    this.resetEditedInstructorDetails();
+  }
+
+  /**
+   * Resets the edited instructor details to the original details.
+   */
+  resetEditedInstructorDetails(): void {
+    this.editedInstructorName = this.instructor.name;
+    this.editedInstructorEmail = this.instructor.email;
+    this.editedInstructorInstitution = this.instructor.institution;
   }
 
 }

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
@@ -1,0 +1,17 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import {NewInstructorDataRowComponent} from "./new-instructor-data-row.component";
+
+/**
+ * Module for rows of new instructor data.
+ */
+@NgModule({
+  declarations: [NewInstructorDataRowComponent],
+  exports: [
+    NewInstructorDataRowComponent,
+  ],
+  imports: [
+    CommonModule,
+  ],
+})
+export class NewInstructorDataRowModule { }

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import {NewInstructorDataRowComponent} from "./new-instructor-data-row.component";
+import {FormsModule} from "@angular/forms";
 
 /**
  * Module for rows of new instructor data.
@@ -12,6 +13,7 @@ import {NewInstructorDataRowComponent} from "./new-instructor-data-row.component
   ],
   imports: [
     CommonModule,
+    FormsModule,
   ],
 })
 export class NewInstructorDataRowModule { }

--- a/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
+++ b/src/web/app/components/new-instructor-data-row/new-instructor-data-row.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import {NewInstructorDataRowComponent} from "./new-instructor-data-row.component";
-import {FormsModule} from "@angular/forms";
+import { NewInstructorDataRowComponent } from "./new-instructor-data-row.component";
+import { FormsModule } from "@angular/forms";
 
 /**
  * Module for rows of new instructor data.

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -66,6 +66,7 @@
             <td>
               <div class="button-group" *ngIf="instructor.status === 'PENDING' || instructor.status === 'FAIL'">
                 <button class="action-btn btn btn-sm btn-primary text-nowrap" id="add-instructor-{{ i }}" style="margin-right: 10px;" (click)="addInstructor(i)" [disabled]="activeRequests > 0">Add Instructor</button>
+                <button class="action-btn btn btn-sm btn-info text-nowrap" id="edit-instructor-{{ i }}" style="margin-right: 10px;">Edit</button>
                 <button class="action-btn btn btn-sm btn-danger" id="cancel-instructor-{{ i }}" (click)="cancelInstructor(i)">Cancel</button>
               </div>
             </td>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -59,25 +59,14 @@
           </tr>
         </thead>
         <tbody>
-          <tr *ngFor="let instructor of instructorsConsolidated; let i = index">
-            <td>{{ instructor.name }}</td>
-            <td>{{ instructor.email }}</td>
-            <td>{{ instructor.institution }}</td>
-            <td>
-              <div class="button-group" *ngIf="instructor.status === 'PENDING' || instructor.status === 'FAIL'">
-                <button class="action-btn btn btn-sm btn-primary text-nowrap" id="add-instructor-{{ i }}" style="margin-right: 10px;" (click)="addInstructor(i)" [disabled]="activeRequests > 0">Add Instructor</button>
-                <button class="action-btn btn btn-sm btn-info text-nowrap" id="edit-instructor-{{ i }}" style="margin-right: 10px;">Edit</button>
-                <button class="action-btn btn btn-sm btn-danger" id="cancel-instructor-{{ i }}" (click)="cancelInstructor(i)">Cancel</button>
-              </div>
-            </td>
-            <td>{{ instructor.status }}</td>
-            <td style="width: 500px;">
-              <span *ngIf="instructor.status === 'SUCCESS'" id="message-instructor-{{ i }}">
-                Instructor "{{ instructor.name }}" has been successfully created. [<a href="{{ instructor.joinLink }}">join link</a>]
-              </span>
-              <span class="message" *ngIf="instructor.status === 'FAIL'" id="message-instructor-{{ i }}">{{ instructor.message }}</span>
-            </td>
-          </tr>
+          <tr tm-new-instructor-data-row
+              *ngFor="let instructor of instructorsConsolidated; let i = index"
+              [instructor]="instructor"
+              [index]="i"
+              [activeRequests]="activeRequests"
+              (onAddInstructor)="addInstructor(i)"
+              (onCancelInstructor)="cancelInstructor(i)"
+          ></tr>
         </tbody>
       </table>
       <button class="btn btn-primary top-padded" (click)="addAllInstructors()" id="add-all-instructors" [disabled]="activeRequests > 0 || isAddingInstructors">

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -65,7 +65,7 @@
               [index]="i"
               [activeRequests]="activeRequests"
               (onAddInstructor)="addInstructor(i)"
-              (onCancelInstructor)="cancelInstructor(i)"
+              (onRemoveInstructor)="removeInstructor(i)"
               (onToggleEditMode)="setInstructorRowEditModeEnabled(i, $event)"
           ></tr>
         </tbody>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.html
@@ -66,6 +66,7 @@
               [activeRequests]="activeRequests"
               (onAddInstructor)="addInstructor(i)"
               (onCancelInstructor)="cancelInstructor(i)"
+              (onToggleEditMode)="setInstructorRowEditModeEnabled(i, $event)"
           ></tr>
         </tbody>
       </table>

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -106,12 +106,18 @@ export class AdminHomePageComponent {
   }
 
   /**
-   * Cancels the instructor at the i-th index.
+   * Removes the instructor at the i-th index.
    */
-  cancelInstructor(i: number): void {
+  removeInstructor(i: number): void {
     this.instructorsConsolidated.splice(i, 1);
   }
 
+  /**
+   * Sets the i-th instructor data row's edit mode status.
+   *
+   * @param i The index.
+   * @param isEnabled Whether the edit mode status is enabled.
+   */
   setInstructorRowEditModeEnabled(i: number, isEnabled: boolean): void {
     this.isInstructorRowEditModeEnabled[i] = isEnabled;
   }

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -3,7 +3,7 @@ import { finalize } from 'rxjs/operators';
 import { AccountService } from '../../../services/account.service';
 import { JoinLink } from '../../../types/api-output';
 import { ErrorMessageOutput } from '../../error-message-output';
-import {InstructorData} from "../../components/new-instructor-data-row/instructor-data";
+import { InstructorData } from "../../components/new-instructor-data-row/instructor-data";
 
 /**
  * Admin home page.

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -21,6 +21,7 @@ export class AdminHomePageComponent {
   instructorInstitution: string = '';
 
   instructorsConsolidated: InstructorData[] = [];
+  isInstructorRowEditModeEnabled: boolean[] = [];
   activeRequests: number = 0;
 
   isAddingInstructors: boolean = false;
@@ -50,6 +51,7 @@ export class AdminHomePageComponent {
         institution: instructorDetailSplit[2],
         status: 'PENDING',
       });
+      this.isInstructorRowEditModeEnabled.push(false);
     }
     this.instructorDetails = invalidLines.join('\r\n');
   }
@@ -68,6 +70,7 @@ export class AdminHomePageComponent {
       institution: this.instructorInstitution,
       status: 'PENDING',
     });
+    this.isInstructorRowEditModeEnabled.push(false);
     this.instructorName = '';
     this.instructorEmail = '';
     this.instructorInstitution = '';
@@ -78,7 +81,7 @@ export class AdminHomePageComponent {
    */
   addInstructor(i: number): void {
     const instructor: InstructorData = this.instructorsConsolidated[i];
-    if (instructor.status !== 'PENDING' && instructor.status !== 'FAIL') {
+    if (this.isInstructorRowEditModeEnabled[i] || (instructor.status !== 'PENDING' && instructor.status !== 'FAIL')) {
       return;
     }
     this.activeRequests += 1;
@@ -107,6 +110,10 @@ export class AdminHomePageComponent {
    */
   cancelInstructor(i: number): void {
     this.instructorsConsolidated.splice(i, 1);
+  }
+
+  setInstructorRowEditModeEnabled(i: number, isEnabled: boolean): void {
+    this.isInstructorRowEditModeEnabled[i] = isEnabled;
   }
 
   /**

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.component.ts
@@ -3,15 +3,7 @@ import { finalize } from 'rxjs/operators';
 import { AccountService } from '../../../services/account.service';
 import { JoinLink } from '../../../types/api-output';
 import { ErrorMessageOutput } from '../../error-message-output';
-
-interface InstructorData {
-  name: string;
-  email: string;
-  institution: string;
-  status: string;
-  joinLink?: string;
-  message?: string;
-}
+import {InstructorData} from "../../components/new-instructor-data-row/instructor-data";
 
 /**
  * Admin home page.

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.module.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.module.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { AdminHomePageComponent } from './admin-home-page.component';
+import {NewInstructorDataRowModule} from "../../components/new-instructor-data-row/new-instructor-data-row.module";
 
 const routes: Routes = [
   {
@@ -27,6 +28,7 @@ const routes: Routes = [
     FormsModule,
     RouterModule.forChild(routes),
     AjaxLoadingModule,
+    NewInstructorDataRowModule,
   ],
 })
 export class AdminHomePageModule { }

--- a/src/web/app/pages-admin/admin-home-page/admin-home-page.module.ts
+++ b/src/web/app/pages-admin/admin-home-page/admin-home-page.module.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { AjaxLoadingModule } from '../../components/ajax-loading/ajax-loading.module';
 import { AdminHomePageComponent } from './admin-home-page.component';
-import {NewInstructorDataRowModule} from "../../components/new-instructor-data-row/new-instructor-data-row.module";
+import { NewInstructorDataRowModule } from "../../components/new-instructor-data-row/new-instructor-data-row.module";
 
 const routes: Routes = [
   {


### PR DESCRIPTION
For applying for CS3281. As such, it will not completely follow the PR conventions. I highlight that I did not know Angular before submitting my application form, but now I do, which can show that I am able to pick stuff up pretty fast.

**Motivation**

An admin may want to add some instructors to the system. However, they may make some mistakes while doing so. It is possible to redo the addition by deleting the new instructor and adding them again but now with their corrected details. However, this is probably not as convenient as having a more direct edit functionality.

**Outline of Solution**

I added a new button, the `Edit` button.

![image](https://user-images.githubusercontent.com/65202977/146638923-60d46b33-0d60-4704-b43f-81f5df594b98.png)

You may notice I also renamed the `Cancel` button to `Remove`. This is because I now use `Cancel` for cancelling an edit. So to avoid confusion, I use `Remove` to cancel a pending addition. I think this is equivalent to just removing that pending addition, hence the name.

`Add Instructor` and (now newly named) `Remove` still work exactly the same. `Edit` changes the UI from having the row appearing similarly as it used to before my changes:

![image](https://user-images.githubusercontent.com/65202977/146639117-9c0c5f62-126d-4096-a479-7c15850c10bf.png)

to having a row with different buttons after pressing `Edit` for Instructor "Yee2" in this case. There are now also text input fields with the corresponding data for that row. These fields can be used to perform the edits.

![image](https://user-images.githubusercontent.com/65202977/146639148-4507b734-8f91-4e6d-a405-532411a5ca96.png)

I decided to have the set of buttons change rather than adding more buttons because I felt that otherwise, it would be cluttered with buttons.

Clicking `Confirm` confirms the edit while clicking `Cancel` cancels the edit. Since the instructor has not been added to the database yet until `Add Instructor` is clicked, it is sufficient to handle these edits within the front-end.

Notice also that it is possible to edit two different instructors simultaneously.

![image](https://user-images.githubusercontent.com/65202977/146639473-4aab154b-1f09-47bc-9c91-2b799f289140.png)

I allowed this because I felt restricting this would be unnecessary. However, extra work was required in order to allow this. This requires each row to maintain some state for whether it is being edited, and also maintain some way to know how it is being edited (such as through variables). This was solved by creating an Angular component for the row, allowing it to have its own class which can be instantiated to maintain the state and variables. This is also mentioned in [the "Create component for a row of new instructor data" commit](https://github.com/jayasting98/teammates/commit/45ef814ad4ab64b97a51cc4fbf02bce5371da2cf).

It is possible for the user to click `Add All Instructors` while some of the rows are in edit mode. There may be a case where the user may not have finished editing the instructor row data but they clicked this. Since the edit is incomplete, it is undesirable to add this instructor with only partially edited or partially correct data. Thus, when `Add All Instructors` is clicked, the instructors of any rows in edit mode are not added. Only when they are moved out of edit mode (either through confirming the edit or cancelling the edit) can they be added when the button is clicked.

<!-- Tell us how you solved the issue. -->
<!-- If there are things you want the reviewers to focus on, include them here as well. -->
<!-- This portion can be skipped if the fix is trivial. -->
